### PR TITLE
Update Developer description to satisfy number/buy and number/cancel request format

### DIFF
--- a/src/descriptions/Developer.php
+++ b/src/descriptions/Developer.php
@@ -211,25 +211,25 @@
                 'api_key' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
                 'api_secret' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
                 'country' => [
                     // Options: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                     'minLength' => 2,
                     'maxLength' => 2,
                 ],
                 'msisdn' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
             ],
         ],
@@ -242,25 +242,25 @@
                 'api_key' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
                 'api_secret' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
                 'country' => [
                     // Options: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                     'minLength' => 2,
                     'maxLength' => 2,
                 ],
                 'msisdn' => [
                     'required' => true,
                     'type' => 'string',
-                    'location' => 'json',
+                    'location' => 'query',
                 ],
             ],
         ],


### PR DESCRIPTION
As per my previous pull request, some of the parameters for the Developer/Number endpoints are required to be in the query string or URI and not the json body.
