### PR TITLE
Fixed descriptions schema additionalParameters placement

### DIFF
--- a/src/descriptions/Alert.php
+++ b/src/descriptions/Alert.php
@@ -47,12 +47,12 @@ return [
                     'enum' => [
                         'text', 'unicode'
                     ]
-                ],
-                'additionalParameters' => [
-                    'required' => false,
-                    'type' => 'string',
-                    'location' => 'json',
                 ]
+            ],
+            'additionalParameters' => [
+                'required' => false,
+                'type' => 'string',
+                'location' => 'json',
             ]
         ]
     ],


### PR DESCRIPTION
I put `additionalParameters` in a wrong place in the descriptions schema array. It's fixed and tested.
